### PR TITLE
Updated deploy-dev.yaml to implement versioning.

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -41,3 +41,7 @@ jobs:
           --include='assets/***' \
           --exclude='*' \
           ./ ${{env.dest}}
+    - name: Update version number
+      run: |
+          TIMESTAMP = date '+%s'
+          sed -i "s/VERSIONNUMBER/$TIMESTAMP" index.html


### PR DESCRIPTION
We're using the UNIX timestamp on the VM to give a version number to .js files. This should prevent browsers from using outdated cached .js